### PR TITLE
Fix wonky navbar layout

### DIFF
--- a/src/components/static/Navbar.scss
+++ b/src/components/static/Navbar.scss
@@ -45,9 +45,8 @@ header {
         }
 
         nav {
-            display: grid;
-            grid-gap: 16px;
-            grid-template-columns: repeat(5, auto);
+            display: flex;
+            gap: 16px;
             align-items: center;
 
             a {


### PR DESCRIPTION
My bad for not checking for layout issues before pushing a PR up 😅 Sorry. The nav used `display: grid;` and hard coded the number of columns, causing the buy tickets button to wrap to a new row. Changing to flexbox fixes this.

<img width="1452" alt="image" src="https://user-images.githubusercontent.com/8438991/223574437-201898bc-ed69-4702-90ee-56e8d33803f3.png">